### PR TITLE
style all usernames when mute/unmute

### DIFF
--- a/robin.user.js
+++ b/robin.user.js
@@ -675,13 +675,15 @@
         var username = String($(this).text()).trim();
         var clickedUser = mutedList.indexOf(username);
 
+        var $userNames = $(".robin--username:contains(" + username + ")");
+
         if (clickedUser == -1) {
             // Mute our user.
             mutedList.push(username);
-            this.style.textDecoration = "line-through";
+            $userNames.css({textDecoration: "line-through"});
         } else {
             // Unmute our user.
-            this.style.textDecoration = "none";
+            $userNames.css({textDecoration: "none"});
             mutedList.splice(clickedUser, 1);
         }
 


### PR DESCRIPTION
When muting by left clicking all occurrences of that username are now striked through or not, instead of just the element you interacted with.
