### PR TITLE
fix #103 more performant time remaining, now with greasemonkey support

### DIFF
--- a/robin.user.js
+++ b/robin.user.js
@@ -1163,11 +1163,6 @@
         return dropdownChannel();
     }
 
-    function updateTextCounter()
-    {
-        $("#textCounterDisplayAlt").text(String(Math.max(140 - Math.floor($("#robinMessageText").val().length), 0)));
-    }
-
     //
     // Update the message prepared for sending to server
     //
@@ -1187,7 +1182,8 @@
         else
             dest.val(chanPrefix + source);
 
-        updateTextCounter();
+        // Use backbones jQuery to trigger an input event, causes update on TextCounter
+        Backbone.$("#robinMessageText").trigger("input");
     }
 
     var pastMessageQueue = [];
@@ -1501,12 +1497,15 @@
     // Message input box (hidden)
     $(".text-counter-input").attr("id", "robinMessageText");
 
-    $(".text-counter-display")
-      .css("display", "none")
-      .after('<span id="textCounterDisplayAlt">140</span>');
-
     $("#robinSendMessage").append('<input type="text" id="robinMessageTextAlt" class="c-form-control text-counter-input" name="messageAlt" autocomplete="off" maxlength="140" required="">');
     $("#robinMessageText").css("display", "none");
+
+    // Override TextCounter update method, uses channel filter in count
+    var originalTextCounterUpdate = r.ui.TextCounter.prototype.update;
+    r.ui.TextCounter.prototype.update = function() {
+        originalTextCounterUpdate.apply(this, [$("#robinMessageText").val()]);
+    }
+
     // Alternate message input box (doesn't show the channel prefixes)
     $("#robinMessageTextAlt").on("input", function() { updateMessage(); });
     $("#robinMessageTextAlt")

--- a/robin.user.js
+++ b/robin.user.js
@@ -1183,7 +1183,7 @@
             dest.val(chanPrefix + source);
 
         // Use backbones jQuery to trigger an input event, causes update on TextCounter
-        Backbone.$("#robinMessageText").trigger("input");
+        window.eval("Backbone.$('#robinMessageText').trigger('input');");
     }
 
     var pastMessageQueue = [];
@@ -1501,10 +1501,12 @@
     $("#robinMessageText").css("display", "none");
 
     // Override TextCounter update method, uses channel filter in count
-    var originalTextCounterUpdate = r.ui.TextCounter.prototype.update;
-    r.ui.TextCounter.prototype.update = function() {
-        originalTextCounterUpdate.apply(this, [$("#robinMessageText").val()]);
-    }
+    window.eval("\
+        var originalTextCounterUpdate = r.ui.TextCounter.prototype.update;\
+        r.ui.TextCounter.prototype.update = function() {\
+            originalTextCounterUpdate.apply(this, [$('#robinMessageText').val()]);\
+        }\
+    ");
 
     // Alternate message input box (doesn't show the channel prefixes)
     $("#robinMessageTextAlt").on("input", function() { updateMessage(); });


### PR DESCRIPTION
Unfortunately to get greasemonkey working I have to use window.eval. Which I see we are using elsewhere already in the script. The reason for this is explained here: http://wiki.greasespot.net/Content_Script_Injection

By calling window.eval we can execute the code in the correct page context. If I can do anything to improve this let me know.
