### PR TITLE
restore the channel stored in the url if one exists

### DIFF
--- a/robin.user.js
+++ b/robin.user.js
@@ -999,6 +999,9 @@
 
         // Add rooms
         resetChannels();
+
+        // Restore the selected channel in the url
+        if (channelList[window.location.hash.charAt(8)]) selectChannel(window.location.hash);
     }
 
     function resetChannels()


### PR DESCRIPTION
Abstracts the channel index from the location.hash. Checks that a channel exists at that index. Navigates to that channel after multi channel setup.
